### PR TITLE
fix(dsp): :bug: Fixed wrong size in special DSP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qosst-bob"
-version = "0.10.0"
+version = "0.10.1"
 description = "Bob submodule of QOSST, containing modules for Bob client, the GUI, the DSP of Bob and parameters estimation."
 authors = [
     "Yoann Piétri <Yoann.Pietri@lip6.fr>",

--- a/qosst_bob/__init__.py
+++ b/qosst_bob/__init__.py
@@ -17,4 +17,4 @@
 """
 QOSST module for Bob.
 """
-__version__ = "0.10.0"
+__version__ = "0.10.1"

--- a/qosst_bob/dsp/dsp.py
+++ b/qosst_bob/dsp/dsp.py
@@ -1367,7 +1367,7 @@ def _special_dsp_params(
         -1j
         * 2
         * np.pi
-        * np.arange(len(elec_noise_data))
+        * np.arange(len(elec_shot_noise_data))
         * frequency_shift
         / adc_rate
     )


### PR DESCRIPTION
Fix critical bug.
Fixed the size of the demodulation exponential in the special DSP for the electronic and shot noise case. Close #1.