### PR TITLE
fix(gui): :bug: Replace PySimpleGUI by FreeSimpleGUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "qosst-bob"
-version = "0.10.1"
+version = "0.10.2"
 description = "Bob submodule of QOSST, containing modules for Bob client, the GUI, the DSP of Bob and parameters estimation."
 authors = [
     "Yoann Piétri <Yoann.Pietri@lip6.fr>",
@@ -35,9 +35,8 @@ matplotlib = [
     { version = "^3.5.1", python = ">=3.9, <3.11" },
     { version = "^3.7.1", python = ">=3.11, <3.13" },
 ]
-PySimpleGUI = "^4.57.0 "
 scipy = "^1.10"
-
+freesimplegui = "^5.1.0"
 
 [tool.poetry.group.dev.dependencies]
 myst-parser = "^1.0.0"

--- a/qosst_bob/__init__.py
+++ b/qosst_bob/__init__.py
@@ -17,4 +17,4 @@
 """
 QOSST module for Bob.
 """
-__version__ = "0.10.1"
+__version__ = "0.10.2"

--- a/qosst_bob/gui/bobgui.py
+++ b/qosst_bob/gui/bobgui.py
@@ -23,7 +23,7 @@ import argparse
 from typing import Union, List, Tuple, Optional
 
 import numpy as np
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import matplotlib
 import matplotlib.pyplot as plt
 

--- a/qosst_bob/gui/figures.py
+++ b/qosst_bob/gui/figures.py
@@ -41,7 +41,7 @@ import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 
 from qosst_bob.bob import Bob
 from qosst_bob.utils import heatmap_complex

--- a/qosst_bob/gui/layout.py
+++ b/qosst_bob/gui/layout.py
@@ -17,7 +17,7 @@
 """
 Layout for Bob gui.
 """
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 
 from qosst_bob import __version__
 from qosst_bob.gui.figures import all_figures


### PR DESCRIPTION
PySimpleGUI has recently changed its economical model and version 5 now requires a license. Previous versions of PySimpleGUI have yanked and are difficult to install using Poetry. Moving to FreeSimpleGUI which is a port of previous versions  of PySimpleGUI